### PR TITLE
feat(runtime): add ENVHAVEN_DISABLE_WEBUI option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,9 @@ PGID=1000
 TZ=America/New_York
 DEFAULT_WORKSPACE=/config/workspace
 
+# Set to true to disable web UI (SSH-only mode)
+# ENVHAVEN_DISABLE_WEBUI=true
+
 # ===================
 # Authentication (REQUIRED)
 # ===================

--- a/Dockerfile
+++ b/Dockerfile
@@ -133,6 +133,7 @@ RUN mkdir -p /etc/s6-overlay/s6-rc.d/init-extensions/dependencies.d \
              /etc/s6-overlay/s6-rc.d/init-zsh-config/dependencies.d \
              /etc/s6-overlay/s6-rc.d/svc-sshd/dependencies.d \
              /etc/s6-overlay/s6-rc.d/svc-cloudflared/dependencies.d \
+             /etc/s6-overlay/s6-rc.d/svc-webui-gate/dependencies.d \
              /etc/s6-overlay/s6-rc.d/user/contents.d
 
 COPY runtime/scripts/init-extensions-run /etc/s6-overlay/s6-rc.d/init-extensions/run
@@ -142,6 +143,7 @@ COPY runtime/scripts/init-user-config-run /etc/s6-overlay/s6-rc.d/init-user-conf
 COPY runtime/scripts/init-zsh-config-run /etc/s6-overlay/s6-rc.d/init-zsh-config/run
 COPY runtime/scripts/svc-sshd-run /etc/s6-overlay/s6-rc.d/svc-sshd/run
 COPY runtime/scripts/svc-cloudflared-run /etc/s6-overlay/s6-rc.d/svc-cloudflared/run
+COPY runtime/scripts/svc-webui-gate-run /etc/s6-overlay/s6-rc.d/svc-webui-gate/run
 
 RUN for svc in init-extensions init-vscode-settings init-agents-md init-user-config init-zsh-config; do \
         echo "oneshot" > /etc/s6-overlay/s6-rc.d/$svc/type && \
@@ -156,7 +158,10 @@ RUN for svc in init-extensions init-vscode-settings init-agents-md init-user-con
     touch /etc/s6-overlay/s6-rc.d/user/contents.d/svc-sshd && \
     echo "longrun" > /etc/s6-overlay/s6-rc.d/svc-cloudflared/type && \
     chmod +x /etc/s6-overlay/s6-rc.d/svc-cloudflared/run && \
-    touch /etc/s6-overlay/s6-rc.d/user/contents.d/svc-cloudflared
+    touch /etc/s6-overlay/s6-rc.d/user/contents.d/svc-cloudflared && \
+    echo "longrun" > /etc/s6-overlay/s6-rc.d/svc-webui-gate/type && \
+    chmod +x /etc/s6-overlay/s6-rc.d/svc-webui-gate/run && \
+    touch /etc/s6-overlay/s6-rc.d/user/contents.d/svc-webui-gate
 
 # ============================================
 # Branding & UI Customization

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,7 @@ Inherited from [linuxserver/code-server](https://docs.linuxserver.io/images/dock
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `ENVHAVEN_MANAGED` | false | Set to `true` for managed hosting mode (affects extension UI) |
+| `ENVHAVEN_DISABLE_WEBUI` | false | Set to `true` to disable the web UI (code-server). SSH access remains available. |
 | `DEFAULT_SHELL` | bash | Set to `zsh` to use zsh as default shell |
 | `HAVEN_IDLE_TIMEOUT` | - | Auto-disconnect Haven CLI sessions after idle period (e.g., `30m`, `2h`, `0` to disable) |
 | `ENVHAVEN_SKIP_WELCOME` | - | Set to `1` to skip auto-attach to tmux on shell start |
@@ -192,12 +193,14 @@ environment:
 
 ## Ports
 
-### EnvHaven Services (always available)
+### EnvHaven Services
 
 | Port | Service |
 |------|---------|
 | 8443 | code-server (VS Code in browser) |
 | 22 | SSH access |
+
+> **Note:** The web UI can be disabled with `ENVHAVEN_DISABLE_WEBUI=true` for SSH-only deployments.
 
 ### User Application Ports (optional)
 
@@ -240,6 +243,31 @@ volumes:
 ```
 
 See `.env.example` in the repository for all available environment variables.
+
+### SSH-Only Mode
+
+For security-focused deployments where you only need terminal access (no web UI):
+
+```yaml
+services:
+  envhaven:
+    image: ghcr.io/envhaven/envhaven:latest
+    container_name: envhaven
+    restart: unless-stopped
+    ports:
+      - "2222:22"     # SSH access only
+    volumes:
+      - envhaven-config:/config
+    environment:
+      - ENVHAVEN_DISABLE_WEBUI=true
+      - SUDO_PASSWORD=yourpassword
+      - PUBLIC_KEY_URL=https://github.com/yourusername.keys
+
+volumes:
+  envhaven-config:
+```
+
+This disables the code-server web UI entirely. Access your environment via SSH or the Haven CLI.
 
 ## Development Configuration
 

--- a/runtime/scripts/svc-webui-gate-run
+++ b/runtime/scripts/svc-webui-gate-run
@@ -1,0 +1,25 @@
+#!/usr/bin/with-contenv bash
+# Web UI gate service - disables code-server if ENVHAVEN_DISABLE_WEBUI=true
+
+if [ "${ENVHAVEN_DISABLE_WEBUI:-}" != "true" ]; then
+    # Web UI enabled (default), this service not needed
+    s6-svc -Od .
+    exit 0
+fi
+
+echo "ENVHAVEN_DISABLE_WEBUI=true: Disabling web UI..."
+
+# Wait for code-server service to exist
+while [ ! -d /run/service/svc-code-server ]; do
+    sleep 0.5
+done
+
+# Bring down code-server and keep it down
+s6-svc -d /run/service/svc-code-server
+echo "Web UI disabled"
+
+# Monitor and keep code-server down (in case something tries to restart it)
+while true; do
+    sleep 5
+    s6-svc -d /run/service/svc-code-server 2>/dev/null
+done


### PR DESCRIPTION
## Summary

- Add `ENVHAVEN_DISABLE_WEBUI` environment variable to optionally disable the web UI
- Create `webui-gate` service to control caddy startup based on this setting
- Update documentation with new configuration option

## Use Case

Useful for headless deployments or when using only SSH/editor tunnels without the web interface.

## Test Plan

- [x] Build container with changes
- [x] Verify `ENVHAVEN_DISABLE_WEBUI=true` prevents caddy from starting
- [x] Verify default behavior (web UI enabled) is unchanged